### PR TITLE
Fix missing std headers include

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Everything should be fairly self-contained, and built with:
 
 # How to use
 
-The API operates on `struct mini_gz` structures, which are containers for
+The API operates on `struct mini_gzip` structures, which are containers for
 the memory with GZIPed data. You must call `mini_gz_init()` on the structure
 1st for the rest of the API to work correctly. Next, you must call
 `mini_gz_start(&gz, mem_in, size)`, where `gz` is the initialized container

--- a/mini_gzip.h
+++ b/mini_gzip.h
@@ -1,6 +1,9 @@
 #ifndef _MINI_GZIP_H_
 #define _MINI_GZIP_H_
 
+#include <stddef.h>
+#include <stdint.h>
+
 #define MAX_PATH_LEN		1024
 #define	MINI_GZ_MIN(a, b)	((a) < (b) ? (a) : (b))
 


### PR DESCRIPTION
1. add missing include in mini_gzip.h
2. Fix spelling error in README