### PR TITLE
MZ_STREAM_END must be tested before testing if output buffer is full.

### DIFF
--- a/mini_gzip.c
+++ b/mini_gzip.c
@@ -116,6 +116,10 @@ mini_gz_unpack(struct mini_gzip *gz_ptr, void *mem_out, size_t mem_out_len)
 		s.avail_in += bytes_to_read;
 		ret = mz_inflate(&s, MZ_SYNC_FLUSH);
 		in_bytes_avail -= bytes_to_read;
+		
+		if (ret == MZ_STREAM_END) {
+			break;
+		}
 		if (s.avail_out == 0 && in_bytes_avail != 0) {
 			return (-3);
 		}
@@ -125,9 +129,6 @@ mini_gz_unpack(struct mini_gzip *gz_ptr, void *mem_out, size_t mem_out_len)
 		}
 		if (ret == MZ_DATA_ERROR) {
 			return (-2);
-		}
-		if (ret == MZ_STREAM_END) {
-			break;
 		}
 	}
 	ret = inflateEnd(&s);


### PR DESCRIPTION
Need to test MZ_STREAM_END before testing if the output buffer is full.  Otherwise mini_gz_unpack can fail -3 even though there is no error.